### PR TITLE
chore: use new syntax features

### DIFF
--- a/Cloneable.Sample/DeepClone.cs
+++ b/Cloneable.Sample/DeepClone.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DeepClone
-    {
-        public string A { get; set; }
-        public SimpleClone Simple { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(DeepClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tSimple.A:\t{Simple?.A}" +
-                Environment.NewLine +
-                $"\tSimple.B:\t{Simple?.B}";
-        }
+[Cloneable]
+public partial class DeepClone
+{
+    public string A { get; set; }
+    public SimpleClone Simple { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(DeepClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tSimple.A:\t{Simple?.A}" +
+            Environment.NewLine +
+            $"\tSimple.B:\t{Simple?.B}";
     }
 }

--- a/Cloneable.Sample/ListClone.cs
+++ b/Cloneable.Sample/ListClone.cs
@@ -3,43 +3,42 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-namespace Cloneable.Sample
+namespace Cloneable.Sample;
+
+[Cloneable]
+public partial class ListClone
 {
-    [Cloneable]
-    public partial class ListClone
+    public string A { get; set; }
+
+    public List<int> B { get; set; }
+    public List<ListClone> Self { get; set; }
+    public List<ListClone?> NullableList { get; set; }
+    public Dictionary<int, ListClone> Dict { get; set; }
+    public Queue<int> Queue { get; set; }
+    public ConcurrentQueue<int> ConcurrentQueue { get; set; }
+    public int[] Arr { get; set; }
+    public ArrayList ArrList { get; set; }
+    public Stack<int> Stack { get; set; }
+    public ConcurrentStack<int> ConcurrentStack { get; set; }
+    public LinkedList<int> LinkedList { get; set; }
+    public ConcurrentDictionary<int, int> ConcurrentDictionary { get; set; }
+    public Queue<SimpleClone> Queue2 { get; set; }
+    public ConcurrentQueue<SimpleClone> ConcurrentQueue2 { get; set; }
+    public SimpleClone[] Arr2 { get; set; }
+    public Stack<SimpleClone> Stack2 { get; set; }
+    public ConcurrentStack<SimpleClone> ConcurrentStack2 { get; set; }
+    public LinkedList<SimpleClone> LinkedList2 { get; set; }
+    public ConcurrentDictionary<int, SimpleClone> ConcurrentDictionary2 { get; set; }
+    public SortedList<int, int> SortList { get; set; }
+    public SortedList<int, SimpleClone> SortedList2 { get; set; }
+
+
+
+    public override string ToString()
     {
-        public string A { get; set; }
-
-        public List<int> B { get; set; }
-        public List<ListClone> Self { get; set; }
-        public List<ListClone?> NullableList { get; set; }
-        public Dictionary<int, ListClone> Dict { get; set; }
-        public Queue<int> Queue { get; set; }
-        public ConcurrentQueue<int> ConcurrentQueue { get; set; }
-        public int[] Arr { get; set; }
-        public ArrayList ArrList { get; set; }
-        public Stack<int> Stack { get; set; }
-        public ConcurrentStack<int> ConcurrentStack { get; set; }
-        public LinkedList<int> LinkedList { get; set; }
-        public ConcurrentDictionary<int, int> ConcurrentDictionary { get; set; }
-        public Queue<SimpleClone> Queue2 { get; set; }
-        public ConcurrentQueue<SimpleClone> ConcurrentQueue2 { get; set; }
-        public SimpleClone[] Arr2 { get; set; }
-        public Stack<SimpleClone> Stack2 { get; set; }
-        public ConcurrentStack<SimpleClone> ConcurrentStack2 { get; set; }
-        public LinkedList<SimpleClone> LinkedList2 { get; set; }
-        public ConcurrentDictionary<int, SimpleClone> ConcurrentDictionary2 { get; set; }
-        public SortedList<int, int> SortList { get; set; }
-        public SortedList<int, SimpleClone> SortedList2 { get; set; }
-
-
-
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Sample/Program.cs
+++ b/Cloneable.Sample/Program.cs
@@ -2,101 +2,100 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Cloneable.Sample
+namespace Cloneable.Sample;
+
+internal static class Program
 {
-    internal static class Program
+    [STAThread]
+    static void Main(string[] args)
     {
-        [STAThread]
-        static void Main(string[] args)
-        {
-            DoSimpleClone();
-            DoSimpleExplicitClone();
-            DoDeepClone();
-            DoSafeDeepClone();
-            DoListClone();
-        }
+        DoSimpleClone();
+        DoSimpleExplicitClone();
+        DoDeepClone();
+        DoSafeDeepClone();
+        DoListClone();
+    }
 
-        static void DoSimpleClone()
+    static void DoSimpleClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var obj = new SimpleClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var obj = new SimpleClone()
-            {
-                A = "salam",
-                B = 100
-            };
-            var clone = obj.Clone();
-            Console.WriteLine(clone);
-            Console.WriteLine("Clone equals original: " + (clone == obj));
-            Console.WriteLine();
-        }
+            A = "salam",
+            B = 100
+        };
+        var clone = obj.Clone();
+        Console.WriteLine(clone);
+        Console.WriteLine("Clone equals original: " + (clone == obj));
+        Console.WriteLine();
+    }
 
-        static void DoSimpleExplicitClone()
+    static void DoSimpleExplicitClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var obj = new SimpleCloneExplicit()
         {
-            // Uses the Clone method on a class with no circular references
-            var obj = new SimpleCloneExplicit()
-            {
-                A = "salam",
-                B = 100
-            };
-            var clone = obj.Clone();
-            Console.WriteLine(clone);
-            Console.WriteLine("Clone equals original: " + (clone == obj));
-            Console.WriteLine();
-        }
+            A = "salam",
+            B = 100
+        };
+        var clone = obj.Clone();
+        Console.WriteLine(clone);
+        Console.WriteLine("Clone equals original: " + (clone == obj));
+        Console.WriteLine();
+    }
 
-        static void DoDeepClone()
+    static void DoDeepClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var obj = new SimpleClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var obj = new SimpleClone()
-            {
-                A = "salam",
-                B = 100
-            };
-            var deep = new DeepClone()
-            {
-                A = "first",
-                Simple = obj
-            };
-            var clone = deep.Clone();
-            Console.WriteLine(clone);
-            Console.WriteLine("Clone equals original: " + (clone == deep));
-            Console.WriteLine();
-        }
+            A = "salam",
+            B = 100
+        };
+        var deep = new DeepClone()
+        {
+            A = "first",
+            Simple = obj
+        };
+        var clone = deep.Clone();
+        Console.WriteLine(clone);
+        Console.WriteLine("Clone equals original: " + (clone == deep));
+        Console.WriteLine();
+    }
 
-        static void DoSafeDeepClone()
+    static void DoSafeDeepClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var child = new SafeDeepCloneChild()
         {
-            // Uses the Clone method on a class with no circular references
-            var child = new SafeDeepCloneChild()
-            {
-                A = "child"
-            };
-            var parent = new SafeDeepClone()
-            {
-                A = "parent",
-                Child = child
-            };
-            child.Parent = parent;
-            var clone = parent.CloneSafe();
-            Console.WriteLine(clone);
-            Console.WriteLine("Clone equals original: " + (clone == parent));
-            Console.WriteLine("Is parents child copied: " + (clone.Child != parent.Child));
-            Console.WriteLine();
-        }
+            A = "child"
+        };
+        var parent = new SafeDeepClone()
+        {
+            A = "parent",
+            Child = child
+        };
+        child.Parent = parent;
+        var clone = parent.CloneSafe();
+        Console.WriteLine(clone);
+        Console.WriteLine("Clone equals original: " + (clone == parent));
+        Console.WriteLine("Is parents child copied: " + (clone.Child != parent.Child));
+        Console.WriteLine();
+    }
 
-        static void DoListClone()
+    static void DoListClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
+        var listClone = new ListClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
-            var listClone = new ListClone()
-            {
-                A = "child",
-                B = list.ToList()
-            };
-            var clone = listClone.CloneSafe();
-            Console.WriteLine(clone);
-            Console.WriteLine("Clone equals original: " + (clone == listClone));
-            Console.WriteLine("List equals original: " + (clone.B == listClone.B));
-            Console.WriteLine();
-        }
+            A = "child",
+            B = list.ToList()
+        };
+        var clone = listClone.CloneSafe();
+        Console.WriteLine(clone);
+        Console.WriteLine("Clone equals original: " + (clone == listClone));
+        Console.WriteLine("List equals original: " + (clone.B == listClone.B));
+        Console.WriteLine();
     }
 }

--- a/Cloneable.Sample/SafeDeepClone.cs
+++ b/Cloneable.Sample/SafeDeepClone.cs
@@ -1,34 +1,33 @@
 using System;
 
-namespace Cloneable.Sample
+namespace Cloneable.Sample;
+
+[Cloneable]
+public partial class SafeDeepClone
 {
-    [Cloneable]
-    public partial class SafeDeepClone
-    {
-        public string A { get; set; }
-        public SafeDeepCloneChild Child { get; set; }
+    public string A { get; set; }
+    public SafeDeepCloneChild Child { get; set; }
 
-        public override string ToString()
-        {
-            return $"{nameof(SafeDeepClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tChild.A:\t{Child?.A}";
-        }
+    public override string ToString()
+    {
+        return $"{nameof(SafeDeepClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tChild.A:\t{Child?.A}";
     }
+}
 
-    [Cloneable]
-    public partial class SafeDeepCloneChild
+[Cloneable]
+public partial class SafeDeepCloneChild
+{
+    public string A { get; set; }
+    public SafeDeepClone Parent { get; set; }
+
+    public override string ToString()
     {
-        public string A { get; set; }
-        public SafeDeepClone Parent { get; set; }
-
-        public override string ToString()
-        {
-            return $"{nameof(SafeDeepCloneChild)}:{Environment.NewLine}" +
-                   $"\tA:\t{A}" +
-                   Environment.NewLine +
-                   $"\tParent.A:\t{Parent?.A}";
-        }
+        return $"{nameof(SafeDeepCloneChild)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tParent.A:\t{Parent?.A}";
     }
 }

--- a/Cloneable.Sample/SimpleClone.cs
+++ b/Cloneable.Sample/SimpleClone.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace Cloneable.Sample
-{
-    [CloneableAttribute]
-    public partial class SimpleClone
-    {
-        public string A { get; set; }
-        
-        [IgnoreClone]
-        public int B { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[CloneableAttribute]
+public partial class SimpleClone
+{
+    public string A { get; set; }
+        
+    [IgnoreClone]
+    public int B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Sample/SimpleCloneExplicit.cs
+++ b/Cloneable.Sample/SimpleCloneExplicit.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace Cloneable.Sample
-{
-    [Cloneable(ExplicitDeclaration = true)]
-    public partial class SimpleCloneExplicit
-    {
-        public string A { get; set; }
-     
-        [Clone]
-        public int B { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleCloneExplicit)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable(ExplicitDeclaration = true)]
+public partial class SimpleCloneExplicit
+{
+    public string A { get; set; }
+     
+    [Clone]
+    public int B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleCloneExplicit)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Snapshots/SnapshotHelpers.cs
+++ b/Cloneable.Snapshots/SnapshotHelpers.cs
@@ -1,5 +1,4 @@
-﻿using Cloneable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Cloneable.Snapshots;

--- a/Cloneable.Test/ArrayClone.cs
+++ b/Cloneable.Test/ArrayClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class ArrayClone
-    {
-        public string A { get; set; }
-        
-        public int[] B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class ArrayClone
+{
+    public string A { get; set; }
+        
+    public int[] B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/DeepArrayClone.cs
+++ b/Cloneable.Test/DeepArrayClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DeepArrayClone
-    {
-        public string A { get; set; }
-        
-        public SimpleClone[] B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class DeepArrayClone
+{
+    public string A { get; set; }
+        
+    public SimpleClone[] B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/DeepClone.cs
+++ b/Cloneable.Test/DeepClone.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DeepClone
-    {
-        public string A { get; set; }
-        public SimpleClone Simple { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(DeepClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tSimple.A:\t{Simple?.A}" +
-                Environment.NewLine +
-                $"\tSimple.B:\t{Simple?.B}";
-        }
+[Cloneable]
+public partial class DeepClone
+{
+    public string A { get; set; }
+    public SimpleClone Simple { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(DeepClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tSimple.A:\t{Simple?.A}" +
+            Environment.NewLine +
+            $"\tSimple.B:\t{Simple?.B}";
     }
 }

--- a/Cloneable.Test/DeepClone.cs
+++ b/Cloneable.Test/DeepClone.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Cloneable.Sample;
 
 [Cloneable]

--- a/Cloneable.Test/DeepCloneNullable.cs
+++ b/Cloneable.Test/DeepCloneNullable.cs
@@ -1,30 +1,29 @@
 ﻿#nullable enable
-namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DeepCloneNullable
-    {
-        public string A { get; set; }
-        public SimpleClone? Simple { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(DeepClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tSimple.A:\t{Simple?.A}" +
-                Environment.NewLine +
-                $"\tSimple.B:\t{Simple?.B}";
-        }
-    }
-    
-    [Cloneable]
-    public partial class DeepCloneNestedNullable
+[Cloneable]
+public partial class DeepCloneNullable
+{
+    public string A { get; set; }
+    public SimpleClone? Simple { get; set; }
+
+    public override string ToString()
     {
-        public string A { get; set; }
-        public SimpleClone?[] Simple { get; set; }
-        public List<SimpleClone>? Simple2 { get; set; }
-        public SimpleClone[]? Simple3 { get; set; }
-        public List<SimpleClone?> Simple4 { get; set; }
+        return $"{nameof(DeepClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tSimple.A:\t{Simple?.A}" +
+            Environment.NewLine +
+            $"\tSimple.B:\t{Simple?.B}";
     }
+}
+    
+[Cloneable]
+public partial class DeepCloneNestedNullable
+{
+    public string A { get; set; }
+    public SimpleClone?[] Simple { get; set; }
+    public List<SimpleClone>? Simple2 { get; set; }
+    public SimpleClone[]? Simple3 { get; set; }
+    public List<SimpleClone?> Simple4 { get; set; }
 }

--- a/Cloneable.Test/DeepDictionaryClone.cs
+++ b/Cloneable.Test/DeepDictionaryClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DeepDictionaryClone
-    {
-        public string A { get; set; }
-        
-        public Dictionary<int, SimpleClone> B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class DeepDictionaryClone
+{
+    public string A { get; set; }
+        
+    public Dictionary<int, SimpleClone> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/DeepEnumerableClone.cs
+++ b/Cloneable.Test/DeepEnumerableClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DeepEnumerableClone
-    {
-        public string A { get; set; }
-        
-        public IEnumerable<SimpleClone> B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class DeepEnumerableClone
+{
+    public string A { get; set; }
+        
+    public IEnumerable<SimpleClone> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/DeepListClone.cs
+++ b/Cloneable.Test/DeepListClone.cs
@@ -1,20 +1,19 @@
 ﻿#nullable enable
 
-namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DeepListClone
-    {
-        public string A { get; set; }
-        
-        public List<SimpleClone> B { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class DeepListClone
+{
+    public string A { get; set; }
+        
+    public List<SimpleClone> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/DictionaryClone.cs
+++ b/Cloneable.Test/DictionaryClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class DictionaryClone
-    {
-        public string A { get; set; }
-        
-        public Dictionary<int, int> B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class DictionaryClone
+{
+    public string A { get; set; }
+        
+    public Dictionary<int, int> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/DuplicateNameClone.cs
+++ b/Cloneable.Test/DuplicateNameClone.cs
@@ -1,11 +1,4 @@
-﻿using Cloneable;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Cloneable.Test.A1
+﻿namespace Cloneable.Test.A1
 {
     [Cloneable]
     public partial class Clone2

--- a/Cloneable.Test/EnumerableClone.cs
+++ b/Cloneable.Test/EnumerableClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class EnumerableClone
-    {
-        public string A { get; set; }
-        
-        public IEnumerable<int> B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class EnumerableClone
+{
+    public string A { get; set; }
+        
+    public IEnumerable<int> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/ListClone.cs
+++ b/Cloneable.Test/ListClone.cs
@@ -4,21 +4,20 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class ListClone
-    {
-        public string A { get; set; }
-        
-        public List<int> B { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class ListClone
+{
+    public string A { get; set; }
+        
+    public List<int> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/ListClone.cs
+++ b/Cloneable.Test/ListClone.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Cloneable.Sample;
+﻿namespace Cloneable.Sample;
 
 [Cloneable]
 public partial class ListClone

--- a/Cloneable.Test/NestedDeepListClone.cs
+++ b/Cloneable.Test/NestedDeepListClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class NestedDeepListClone
-    {
-        public string A { get; set; }
-        
-        public List<List<SimpleClone>> B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class NestedDeepListClone
+{
+    public string A { get; set; }
+        
+    public List<List<SimpleClone>> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/NestedListClone.cs
+++ b/Cloneable.Test/NestedListClone.cs
@@ -1,18 +1,17 @@
-﻿namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class NestedListClone
-    {
-        public string A { get; set; }
-        
-        public List<List<int>> B { get; set; }
+﻿namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class NestedListClone
+{
+    public string A { get; set; }
+        
+    public List<List<int>> B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/SafeDeepClone.cs
+++ b/Cloneable.Test/SafeDeepClone.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Cloneable.Sample;
 
 [Cloneable]

--- a/Cloneable.Test/SafeDeepClone.cs
+++ b/Cloneable.Test/SafeDeepClone.cs
@@ -1,34 +1,33 @@
 using System;
 
-namespace Cloneable.Sample
+namespace Cloneable.Sample;
+
+[Cloneable]
+public partial class SafeDeepClone
 {
-    [Cloneable]
-    public partial class SafeDeepClone
-    {
-        public string A { get; set; }
-        public SafeDeepCloneChild Child { get; set; }
+    public string A { get; set; }
+    public SafeDeepCloneChild Child { get; set; }
 
-        public override string ToString()
-        {
-            return $"{nameof(SafeDeepClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tChild.A:\t{Child?.A}";
-        }
+    public override string ToString()
+    {
+        return $"{nameof(SafeDeepClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tChild.A:\t{Child?.A}";
     }
+}
 
-    [Cloneable]
-    public partial class SafeDeepCloneChild
+[Cloneable]
+public partial class SafeDeepCloneChild
+{
+    public string A { get; set; }
+    public SafeDeepClone Parent { get; set; }
+
+    public override string ToString()
     {
-        public string A { get; set; }
-        public SafeDeepClone Parent { get; set; }
-
-        public override string ToString()
-        {
-            return $"{nameof(SafeDeepCloneChild)}:{Environment.NewLine}" +
-                   $"\tA:\t{A}" +
-                   Environment.NewLine +
-                   $"\tParent.A:\t{Parent?.A}";
-        }
+        return $"{nameof(SafeDeepCloneChild)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tParent.A:\t{Parent?.A}";
     }
 }

--- a/Cloneable.Test/SimpleClone.cs
+++ b/Cloneable.Test/SimpleClone.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace Cloneable.Sample
-{
-    [Cloneable]
-    public partial class SimpleClone
-    {
-        public string A { get; set; }
-        
-        [IgnoreClone]
-        public int B { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable]
+public partial class SimpleClone
+{
+    public string A { get; set; }
+        
+    [IgnoreClone]
+    public int B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleClone)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/SimpleClone.cs
+++ b/Cloneable.Test/SimpleClone.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Cloneable.Sample;
 
 [Cloneable]

--- a/Cloneable.Test/SimpleCloneExplicit.cs
+++ b/Cloneable.Test/SimpleCloneExplicit.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Cloneable.Sample;
 
 [Cloneable(ExplicitDeclaration = true)]

--- a/Cloneable.Test/SimpleCloneExplicit.cs
+++ b/Cloneable.Test/SimpleCloneExplicit.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace Cloneable.Sample
-{
-    [Cloneable(ExplicitDeclaration = true)]
-    public partial class SimpleCloneExplicit
-    {
-        public string A { get; set; }
-     
-        [Clone]
-        public int B { get; set; }
+namespace Cloneable.Sample;
 
-        public override string ToString()
-        {
-            return $"{nameof(SimpleCloneExplicit)}:{Environment.NewLine}" +
-                $"\tA:\t{A}" +
-                Environment.NewLine +
-                $"\tB:\t{B}";
-        }
+[Cloneable(ExplicitDeclaration = true)]
+public partial class SimpleCloneExplicit
+{
+    public string A { get; set; }
+     
+    [Clone]
+    public int B { get; set; }
+
+    public override string ToString()
+    {
+        return $"{nameof(SimpleCloneExplicit)}:{Environment.NewLine}" +
+            $"\tA:\t{A}" +
+            Environment.NewLine +
+            $"\tB:\t{B}";
     }
 }

--- a/Cloneable.Test/Tests.cs
+++ b/Cloneable.Test/Tests.cs
@@ -3,327 +3,326 @@ using FluentAssertions;
 using System;
 using System.Collections.Generic;
 
-namespace Cloneable.Test
+namespace Cloneable.Test;
+
+public class Tests
 {
-    public class Tests
+    [Fact]
+    public void DoSimpleClone()
     {
-        [Fact]
-        public void DoSimpleClone()
+        // Uses the Clone method on a class with no circular references
+        var obj = new SimpleClone()
         {
-            // Uses the Clone method on a class with no circular references
+            A = "salam",
+            B = 100
+        };
+        var clone = obj.Clone();
+        clone.Should().NotBe(obj);
+    }
+
+    [Fact]
+    public void DoSimpleExplicitClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var obj = new SimpleCloneExplicit()
+        {
+            A = "salam",
+            B = 100
+        };
+        var clone = obj.Clone();
+        clone.Should().NotBe(obj);
+    }
+
+    [Fact]
+    public void DoDeepClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var obj = new SimpleClone()
+        {
+            A = "salam",
+            B = 100
+        };
+        var deep = new DeepClone()
+        {
+            A = "first",
+            Simple = obj
+        };
+        var clone = deep.Clone();
+        clone.Should().NotBe(deep);
+    }
+
+    [Fact]
+    public void DoSafeDeepClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var child = new SafeDeepCloneChild()
+        {
+            A = "child"
+        };
+        var parent = new SafeDeepClone()
+        {
+            A = "parent",
+            Child = child
+        };
+        child.Parent = parent;
+        var clone = parent.CloneSafe();
+        clone.Should().NotBe(parent);
+        clone.Child.Should().NotBe(parent.Child);
+    }
+
+    [Fact]
+    public void DoSimpleListClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
+        var listClone = new ListClone()
+        {
+            A = "child",
+            B = list
+        };
+        var clone = listClone.CloneSafe();
+        clone.Should().NotBe(listClone);
+        var listEqual = clone.B == listClone.B;
+        listEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoNestedSimpleListClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
+        var listClone = new NestedListClone()
+        {
+            A = "child",
+            B = new List<List<int>>() { list }
+        };
+        var clone = listClone.CloneSafe();
+        clone.Should().NotBe(listClone);
+        var listEqual = clone.B == listClone.B;
+        listEqual.Should().BeFalse();
+        var nestedListEqual = clone.B[0] == listClone.B[0];
+        nestedListEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoNestedDeepListClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<SimpleClone>();
+        for (int x = 0; x < 5; x++)
+        {
             var obj = new SimpleClone()
             {
                 A = "salam",
-                B = 100
+                B = Random.Shared.Next()
             };
-            var clone = obj.Clone();
-            clone.Should().NotBe(obj);
+            list.Add(obj);
         }
-
-        [Fact]
-        public void DoSimpleExplicitClone()
+        var listClone = new NestedDeepListClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var obj = new SimpleCloneExplicit()
-            {
-                A = "salam",
-                B = 100
-            };
-            var clone = obj.Clone();
-            clone.Should().NotBe(obj);
-        }
+            A = "child",
+            B = new List<List<SimpleClone>>() { list }
+        };
+        var clone = listClone.CloneSafe();
+        clone.Should().NotBe(listClone);
+        var listEqual = clone.B == listClone.B;
+        listEqual.Should().BeFalse();
+        var nestedListEqual = clone.B[0] == listClone.B[0];
+        nestedListEqual.Should().BeFalse();
+    }
 
-        [Fact]
-        public void DoDeepClone()
+    [Fact]
+    public void DoSimpleDictionaryClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
+        var listClone = new DictionaryClone()
         {
-            // Uses the Clone method on a class with no circular references
+            A = "child",
+            B = list.ToDictionary(x => x)
+        };
+        var clone = listClone.CloneSafe();
+        clone.Should().NotBe(listClone);
+        var listEqual = clone.B == listClone.B;
+        listEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoDeepListClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<SimpleClone>();
+        for (int x = 0; x < 5; x++)
+        {
             var obj = new SimpleClone()
             {
                 A = "salam",
-                B = 100
+                B = Random.Shared.Next()
             };
-            var deep = new DeepClone()
-            {
-                A = "first",
-                Simple = obj
-            };
-            var clone = deep.Clone();
-            clone.Should().NotBe(deep);
+            list.Add(obj);
         }
-
-        [Fact]
-        public void DoSafeDeepClone()
+        var listClone = new DeepListClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var child = new SafeDeepCloneChild()
-            {
-                A = "child"
-            };
-            var parent = new SafeDeepClone()
-            {
-                A = "parent",
-                Child = child
-            };
-            child.Parent = parent;
-            var clone = parent.CloneSafe();
-            clone.Should().NotBe(parent);
-            clone.Child.Should().NotBe(parent.Child);
-        }
+            A = "child",
+            B = list
+        };
+        var clone = listClone.CloneSafe();
 
-        [Fact]
-        public void DoSimpleListClone()
+        clone.B.Should().NotBeEquivalentTo(listClone.B);
+        clone.Should().NotBe(listClone);
+        var listEqual = clone.B == listClone.B;
+        listEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoDeepDictionaryClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<SimpleClone>();
+        for (int x = 0; x < 5; x++)
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
-            var listClone = new ListClone()
+            var obj = new SimpleClone()
             {
-                A = "child",
-                B = list
+                A = "salam",
+                B = Random.Shared.Next()
             };
-            var clone = listClone.CloneSafe();
-            clone.Should().NotBe(listClone);
-            var listEqual = clone.B == listClone.B;
-            listEqual.Should().BeFalse();
+            list.Add(obj);
         }
-
-        [Fact]
-        public void DoNestedSimpleListClone()
+        var listClone = new DeepDictionaryClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
-            var listClone = new NestedListClone()
-            {
-                A = "child",
-                B = new List<List<int>>() { list }
-            };
-            var clone = listClone.CloneSafe();
-            clone.Should().NotBe(listClone);
-            var listEqual = clone.B == listClone.B;
-            listEqual.Should().BeFalse();
-            var nestedListEqual = clone.B[0] == listClone.B[0];
-            nestedListEqual.Should().BeFalse();
-        }
+            A = "child",
+            B = list.ToDictionary(x => x.B)
+        };
+        var clone = listClone.CloneSafe();
 
-        [Fact]
-        public void DoNestedDeepListClone()
+        clone.B.Should().NotBeEquivalentTo(listClone.B);
+        clone.Should().NotBe(listClone);
+        var listEqual = clone.B == listClone.B;
+        listEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoSimpleEnumerableClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
+        var enumerableClone = new EnumerableClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<SimpleClone>();
-            for (int x = 0; x < 5; x++)
-            {
-                var obj = new SimpleClone()
-                {
-                    A = "salam",
-                    B = Random.Shared.Next()
-                };
-                list.Add(obj);
-            }
-            var listClone = new NestedDeepListClone()
-            {
-                A = "child",
-                B = new List<List<SimpleClone>>() { list }
-            };
-            var clone = listClone.CloneSafe();
-            clone.Should().NotBe(listClone);
-            var listEqual = clone.B == listClone.B;
-            listEqual.Should().BeFalse();
-            var nestedListEqual = clone.B[0] == listClone.B[0];
-            nestedListEqual.Should().BeFalse();
-        }
+            A = "child",
+            B = list.ToArray()
+        };
+        var clone = enumerableClone.CloneSafe();
+        clone.Should().NotBe(enumerableClone);
+        var listEqual = clone.B == enumerableClone.B;
+        listEqual.Should().BeFalse();
+    }
 
-        [Fact]
-        public void DoSimpleDictionaryClone()
+    [Fact]
+    public void DoDeepEnumerableClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<SimpleClone>();
+        for (int x = 0; x < 5; x++)
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
-            var listClone = new DictionaryClone()
+            var obj = new SimpleClone()
             {
-                A = "child",
-                B = list.ToDictionary(x => x)
+                A = "salam",
+                B = Random.Shared.Next()
             };
-            var clone = listClone.CloneSafe();
-            clone.Should().NotBe(listClone);
-            var listEqual = clone.B == listClone.B;
-            listEqual.Should().BeFalse();
+            list.Add(obj);
         }
-
-        [Fact]
-        public void DoDeepListClone()
+        var enumerableClone = new DeepEnumerableClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<SimpleClone>();
-            for (int x = 0; x < 5; x++)
-            {
-                var obj = new SimpleClone()
-                {
-                    A = "salam",
-                    B = Random.Shared.Next()
-                };
-                list.Add(obj);
-            }
-            var listClone = new DeepListClone()
-            {
-                A = "child",
-                B = list
-            };
-            var clone = listClone.CloneSafe();
+            A = "child",
+            B = list.ToArray()
+        };
+        var clone = enumerableClone.CloneSafe();
+        clone.Should().NotBe(enumerableClone);
+        var listEqual = clone.B == enumerableClone.B;
+        listEqual.Should().BeFalse();
+    }
 
-            clone.B.Should().NotBeEquivalentTo(listClone.B);
-            clone.Should().NotBe(listClone);
-            var listEqual = clone.B == listClone.B;
-            listEqual.Should().BeFalse();
-        }
-
-        [Fact]
-        public void DoDeepDictionaryClone()
+    [Fact]
+    public void DoSimpleArrayClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
+        var enumerableClone = new ArrayClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<SimpleClone>();
-            for (int x = 0; x < 5; x++)
-            {
-                var obj = new SimpleClone()
-                {
-                    A = "salam",
-                    B = Random.Shared.Next()
-                };
-                list.Add(obj);
-            }
-            var listClone = new DeepDictionaryClone()
-            {
-                A = "child",
-                B = list.ToDictionary(x => x.B)
-            };
-            var clone = listClone.CloneSafe();
+            A = "child",
+            B = list.ToArray()
+        };
+        var clone = enumerableClone.CloneSafe();
+        clone.Should().NotBe(enumerableClone);
+        var listEqual = clone.B == enumerableClone.B;
+        listEqual.Should().BeFalse();
+    }
 
-            clone.B.Should().NotBeEquivalentTo(listClone.B);
-            clone.Should().NotBe(listClone);
-            var listEqual = clone.B == listClone.B;
-            listEqual.Should().BeFalse();
-        }
-
-        [Fact]
-        public void DoSimpleEnumerableClone()
+    [Fact]
+    public void DoDeepArrayClone()
+    {
+        // Uses the Clone method on a class with no circular references
+        var list = new List<SimpleClone>();
+        for (int x = 0; x < 5; x++)
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
-            var enumerableClone = new EnumerableClone()
+            var obj = new SimpleClone()
             {
-                A = "child",
-                B = list.ToArray()
+                A = "salam",
+                B = Random.Shared.Next()
             };
-            var clone = enumerableClone.CloneSafe();
-            clone.Should().NotBe(enumerableClone);
-            var listEqual = clone.B == enumerableClone.B;
-            listEqual.Should().BeFalse();
+            list.Add(obj);
         }
-
-        [Fact]
-        public void DoDeepEnumerableClone()
+        var enumerableClone = new DeepArrayClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<SimpleClone>();
-            for (int x = 0; x < 5; x++)
-            {
-                var obj = new SimpleClone()
-                {
-                    A = "salam",
-                    B = Random.Shared.Next()
-                };
-                list.Add(obj);
-            }
-            var enumerableClone = new DeepEnumerableClone()
-            {
-                A = "child",
-                B = list.ToArray()
-            };
-            var clone = enumerableClone.CloneSafe();
-            clone.Should().NotBe(enumerableClone);
-            var listEqual = clone.B == enumerableClone.B;
-            listEqual.Should().BeFalse();
-        }
+            A = "child",
+            B = list.ToArray()
+        };
+        var clone = enumerableClone.CloneSafe();
+        clone.Should().NotBe(enumerableClone);
+        var listEqual = clone.B == enumerableClone.B;
+        listEqual.Should().BeFalse();
+    }
 
-        [Fact]
-        public void DoSimpleArrayClone()
+    [Fact]
+    public void ThrowsOnNonNullable()
+    {
+        var deepClone = new DeepClone()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<int>() { 0, 1, 2, 3, 4, 5 };
-            var enumerableClone = new ArrayClone()
-            {
-                A = "child",
-                B = list.ToArray()
-            };
-            var clone = enumerableClone.CloneSafe();
-            clone.Should().NotBe(enumerableClone);
-            var listEqual = clone.B == enumerableClone.B;
-            listEqual.Should().BeFalse();
-        }
+            A = "test",
+            Simple = null
+        };
 
-        [Fact]
-        public void DoDeepArrayClone()
+        Assert.Throws<NullReferenceException>(deepClone.Clone);
+        Assert.Throws<NullReferenceException>(() => deepClone.CloneSafe());
+    }
+
+    [Fact]
+    public void DoesntThrowOnNullable()
+    {
+        var deepClone = new DeepCloneNullable()
         {
-            // Uses the Clone method on a class with no circular references
-            var list = new List<SimpleClone>();
-            for (int x = 0; x < 5; x++)
-            {
-                var obj = new SimpleClone()
-                {
-                    A = "salam",
-                    B = Random.Shared.Next()
-                };
-                list.Add(obj);
-            }
-            var enumerableClone = new DeepArrayClone()
-            {
-                A = "child",
-                B = list.ToArray()
-            };
-            var clone = enumerableClone.CloneSafe();
-            clone.Should().NotBe(enumerableClone);
-            var listEqual = clone.B == enumerableClone.B;
-            listEqual.Should().BeFalse();
-        }
+            A = "test",
+            Simple = null
+        };
 
-        [Fact]
-        public void ThrowsOnNonNullable()
+        deepClone.Clone();
+        deepClone.CloneSafe();
+    }
+
+
+    [Fact]
+    public void DoesntThrowOnNestedNullable()
+    {
+        var deepClone = new DeepCloneNestedNullable()
         {
-            var deepClone = new DeepClone()
-            {
-                A = "test",
-                Simple = null
-            };
+            A = "test",
+            Simple = [null],
+            Simple3 = null,
+            Simple2 = null,
+            Simple4 = [null]
+        };
 
-            Assert.Throws<NullReferenceException>(deepClone.Clone);
-            Assert.Throws<NullReferenceException>(() => deepClone.CloneSafe());
-        }
-
-        [Fact]
-        public void DoesntThrowOnNullable()
-        {
-            var deepClone = new DeepCloneNullable()
-            {
-                A = "test",
-                Simple = null
-            };
-
-            deepClone.Clone();
-            deepClone.CloneSafe();
-        }
-
-
-        [Fact]
-        public void DoesntThrowOnNestedNullable()
-        {
-            var deepClone = new DeepCloneNestedNullable()
-            {
-                A = "test",
-                Simple = [null],
-                Simple3 = null,
-                Simple2 = null,
-                Simple4 = [null]
-            };
-
-            deepClone.Clone();
-            deepClone.CloneSafe();
-        }
+        deepClone.Clone();
+        deepClone.CloneSafe();
     }
 }

--- a/Cloneable.Test/Tests.cs
+++ b/Cloneable.Test/Tests.cs
@@ -1,7 +1,5 @@
 ﻿using Cloneable.Sample;
 using FluentAssertions;
-using System;
-using System.Collections.Generic;
 
 namespace Cloneable.Test;
 

--- a/Cloneable/IncrementalCloneableGenerator.cs
+++ b/Cloneable/IncrementalCloneableGenerator.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Cloneable/SymbolExtensions.cs
+++ b/Cloneable/SymbolExtensions.cs
@@ -5,139 +5,138 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 
-namespace Cloneable
+namespace Cloneable;
+
+internal static class SymbolExtensions
 {
-    internal static class SymbolExtensions
+    public static bool TryGetAttribute(this ISymbol symbol, INamedTypeSymbol attributeType, out IEnumerable<AttributeData> attributes)
     {
-        public static bool TryGetAttribute(this ISymbol symbol, INamedTypeSymbol attributeType, out IEnumerable<AttributeData> attributes)
-        {
-            attributes = symbol.GetAttributes()
-                .Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeType));
-            return attributes.Any();
-        }
+        attributes = symbol.GetAttributes()
+            .Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeType));
+        return attributes.Any();
+    }
         
-        public static bool TryGetAttribute(this ISymbol symbol, string attributeDisplayStr, out AttributeData? attributes)
-        {
-            attributes = symbol.GetAttributes()
-                .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == attributeDisplayStr);
-            return attributes is not null;
-        }
+    public static bool TryGetAttribute(this ISymbol symbol, string attributeDisplayStr, out AttributeData? attributes)
+    {
+        attributes = symbol.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == attributeDisplayStr);
+        return attributes is not null;
+    }
         
-        public static T? RetrieveArgument<T>(this AttributeData? attribute, string namedArgument)
-        {
-            return !attribute.TryGetArgument<T>(namedArgument, out var result) ? default : result;
-        }
+    public static T? RetrieveArgument<T>(this AttributeData? attribute, string namedArgument)
+    {
+        return !attribute.TryGetArgument<T>(namedArgument, out var result) ? default : result;
+    }
         
-        public static bool TryGetArgument<T>(this AttributeData? attribute, string namedArgument, out T? value)
+    public static bool TryGetArgument<T>(this AttributeData? attribute, string namedArgument, out T? value)
+    {
+        if (attribute?.NamedArguments.FirstOrDefault(x => x.Key == namedArgument).Value is not T typedArgument)
         {
-            if (attribute?.NamedArguments.FirstOrDefault(x => x.Key == namedArgument).Value is not T typedArgument)
-            {
-                value = default;
-                return false;
-            }
-
-            value = typedArgument;
-            return true;
+            value = default;
+            return false;
         }
+
+        value = typedArgument;
+        return true;
+    }
         
-        public static bool TryGetArgument<T>(this ISymbol symbol, string attributeDisplayStr, string namedArgument, out T? value)
-        {
-            var attribute = symbol
-                .GetAttributes().FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == attributeDisplayStr);
-            return TryGetArgument(attribute, namedArgument, out value);
-        }
+    public static bool TryGetArgument<T>(this ISymbol symbol, string attributeDisplayStr, string namedArgument, out T? value)
+    {
+        var attribute = symbol
+            .GetAttributes().FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == attributeDisplayStr);
+        return TryGetArgument(attribute, namedArgument, out value);
+    }
         
-        public static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attributeType)
-        {
-            return symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeType));
-        }
+    public static bool HasAttribute(this ISymbol symbol, INamedTypeSymbol attributeType)
+    {
+        return symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeType));
+    }
 
-        // ReSharper disable once InconsistentNaming
-        public static string ToNullableFQF(this ISymbol symbol) =>
-            symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
-                    SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
-                )
-            );
+    // ReSharper disable once InconsistentNaming
+    public static string ToNullableFQF(this ISymbol symbol) =>
+        symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
+                SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+            )
+        );
 
-        // ReSharper disable once InconsistentNaming
-        public static string ToFQF(this ISymbol symbol) =>
-            symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    // ReSharper disable once InconsistentNaming
+    public static string ToFQF(this ISymbol symbol) =>
+        symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         
-        // ReSharper disable once InconsistentNaming
-        public static string ToKnownInterfaceFQF(this ITypeSymbol symbol)
-        {
-            var iDictInterface = symbol.GetInterface("global::System.Collections.Generic.IDictionary<TKey, TValue>");
-            var iListInterface = symbol.GetInterface("global::System.Collections.Generic.IList<T>");
-            if (iDictInterface != null) return iDictInterface.ToFQF();
-            else if (iListInterface != null) return iListInterface.ToFQF();
-            return symbol.ToFQF();
-        }
+    // ReSharper disable once InconsistentNaming
+    public static string ToKnownInterfaceFQF(this ITypeSymbol symbol)
+    {
+        var iDictInterface = symbol.GetInterface("global::System.Collections.Generic.IDictionary<TKey, TValue>");
+        var iListInterface = symbol.GetInterface("global::System.Collections.Generic.IList<T>");
+        if (iDictInterface != null) return iDictInterface.ToFQF();
+        else if (iListInterface != null) return iListInterface.ToFQF();
+        return symbol.ToFQF();
+    }
 
-        public static AttributeData? GetAttribute(this ISymbol symbol, INamedTypeSymbol attribute)
-        {
-            return symbol
-                .GetAttributes()
-                .FirstOrDefault(x => x.AttributeClass?.Equals(attribute, SymbolEqualityComparer.Default) == true);
-        }
+    public static AttributeData? GetAttribute(this ISymbol symbol, INamedTypeSymbol attribute)
+    {
+        return symbol
+            .GetAttributes()
+            .FirstOrDefault(x => x.AttributeClass?.Equals(attribute, SymbolEqualityComparer.Default) == true);
+    }
 
-        public static INamedTypeSymbol? GetInterface(this ITypeSymbol symbol, string interfaceFqn)
-        {
-            return symbol.AllInterfaces
-                .FirstOrDefault(x => x.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == interfaceFqn);
-        }
+    public static INamedTypeSymbol? GetInterface(this ITypeSymbol symbol, string interfaceFqn)
+    {
+        return symbol.AllInterfaces
+            .FirstOrDefault(x => x.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == interfaceFqn);
+    }
 
-        public static ImmutableArray<ITypeSymbol>? GetIEnumerableTypeArguments(this ITypeSymbol symbol)
-        {
-            if (symbol.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.Collections.Generic.IEnumerable<T>") 
-                return ((INamedTypeSymbol)symbol).TypeArguments;
-            return symbol.GetInterface("global::System.Collections.Generic.IEnumerable<T>")?.TypeArguments;
-        }
+    public static ImmutableArray<ITypeSymbol>? GetIEnumerableTypeArguments(this ITypeSymbol symbol)
+    {
+        if (symbol.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.Collections.Generic.IEnumerable<T>") 
+            return ((INamedTypeSymbol)symbol).TypeArguments;
+        return symbol.GetInterface("global::System.Collections.Generic.IEnumerable<T>")?.TypeArguments;
+    }
 
-        public static ImmutableArray<ITypeSymbol>? GetIDictionaryTypeArguments(this ITypeSymbol symbol)
-        {
-            return symbol.GetInterface("global::System.Collections.Generic.IDictionary<TKey, TValue>")?.TypeArguments;
-        }
+    public static ImmutableArray<ITypeSymbol>? GetIDictionaryTypeArguments(this ITypeSymbol symbol)
+    {
+        return symbol.GetInterface("global::System.Collections.Generic.IDictionary<TKey, TValue>")?.TypeArguments;
+    }
 
-        public static bool IsPossibleEnumerable(this ITypeSymbol symbol)
-        {
-            return !symbol.IsValueType && symbol.Name != "String" && (symbol.GetIEnumerableTypeArguments() != null || symbol.GetIDictionaryTypeArguments() != null);
-        }
+    public static bool IsPossibleEnumerable(this ITypeSymbol symbol)
+    {
+        return !symbol.IsValueType && symbol.Name != "String" && (symbol.GetIEnumerableTypeArguments() != null || symbol.GetIDictionaryTypeArguments() != null);
+    }
         
         
-        public static StringBuilder AppendCode(this StringBuilder builder, string value, ushort indent = 0)
+    public static StringBuilder AppendCode(this StringBuilder builder, string value, ushort indent = 0)
+    {
+        for (var i = 0; i < indent; i++)
         {
-            for (var i = 0; i < indent; i++)
-            {
-                builder.Append("    ");
-            }
-
-            return builder.AppendLine(value);
+            builder.Append("    ");
         }
+
+        return builder.AppendLine(value);
+    }
         
-        public static StringBuilder AppendCodeBlock(this StringBuilder builder, string value, ushort indent = 0)
-        {
-            if (string.IsNullOrEmpty(value))
-                return builder;
-
-            // Normalize all line endings to '\n' first so splitting is stable
-            var normalized = value.Replace("\r\n", "\n").Replace("\r", "\n");
-
-            foreach (var line in normalized.Split('\n'))
-            {
-                builder.AppendCode(line, indent);
-            }
-
+    public static StringBuilder AppendCodeBlock(this StringBuilder builder, string value, ushort indent = 0)
+    {
+        if (string.IsNullOrEmpty(value))
             return builder;
-        }
-        
-        public static string ToCapitalized(this string str)
+
+        // Normalize all line endings to '\n' first so splitting is stable
+        var normalized = value.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        foreach (var line in normalized.Split('\n'))
         {
-            return char.ToUpper(str[0]) + str.Substring(1, str.Length - 1);
+            builder.AppendCode(line, indent);
         }
+
+        return builder;
+    }
         
-        public static IEnumerable<T> DistinctBy<T, TKey>(this IEnumerable<T> list, Func<T, TKey> propertySelector)
-        {
-            return list.GroupBy(propertySelector).Select(x => x.First());
-        }
+    public static string ToCapitalized(this string str)
+    {
+        return char.ToUpper(str[0]) + str.Substring(1, str.Length - 1);
+    }
+        
+    public static IEnumerable<T> DistinctBy<T, TKey>(this IEnumerable<T> list, Func<T, TKey> propertySelector)
+    {
+        return list.GroupBy(propertySelector).Select(x => x.First());
     }
 }


### PR DESCRIPTION
Hello! I'm just getting familiar with the codebase, so that I can make some more meaningful feature submissions sometime soon. I figured I'd put together a simple changeset to use newer language features as I get up to speed. There should be no behavioral changes introduced by the changes in PR.

- [Use file-scoped namespaces, remove unused imports](https://github.com/Nickztar/Cloneable/commit/a9cde0327463b7d184bdfa67b305fda61d1f6c1d)
- [Utilize Raw String Literals](https://github.com/Nickztar/Cloneable/commit/743b20a9ad1855afbcac1c5fe4a048416dc719a4) over concatentation in `Cloneable/CloneableGenerator.cs`
- [Put the SyntaxReceiver.cs doc comment... on SyntaxReceiver](https://github.com/Nickztar/Cloneable/commit/3acbf08a7e6a8953a4664fa473f883f3390d8a03) (it was previously floating above the namespace)
- [naming: constructors -> constructor](https://github.com/Nickztar/Cloneable/commit/d6c4dbadb10f73128e225612eac9f7c684bda76b) (minor, where used, it represents a single ctor)


